### PR TITLE
best effort cleanup on write failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ client that returned an md5 hash.
 
 Calls to `writeFile` are atomic on all clients.  It will write to a
 temporary file like `foo.txt.TMP.cafef00d` and then rename to
-`foo.txt` when finished.  At this time, it does not attempt to clean
-up these tmp files on a failed write.
+`foo.txt` when finished.  If the write fails, it makes a best effort
+attempt to unlink the temporary file.
 
 ### Stat Objects
 

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -63,7 +63,10 @@ MultiFSClient.prototype.writeFile = function(dest, data, enc, cb) {
   makeTmpName(dest, function(err, tmpfile) {
     if (err) return cb(err)
     this._writeFileCore(tmpfile, data, enc, function(err) {
-      if (err) return cb(err)
+      // Best effort removal of temp file on write failure
+      if (err) return this.unlink(tmpfile, function(err2) {
+        return cb(err, null, err2)
+      })
       this.rename(tmpfile, dest, cb)
     }.bind(this))
   }.bind(this))


### PR DESCRIPTION
Hard to write a test for this, since it would only happen in unusual
situations, but at least we can TRY not to leave litter lying around.

There is of course the possibility that a write fails because a file
already exists with the name foo.txt.TMP.cafef00d, and then the
subsequent unlink causes problems.  But in that case, we've already
obliterated the file anyway (or we don't have permission to unlink it)
and it's super unlikely because crypto randoms.

Review plz, @ceejbot 
