### PR TITLE
Made the ssh rename unlink the destination first.

### DIFF
--- a/lib/client-ssh.js
+++ b/lib/client-ssh.js
@@ -312,5 +312,12 @@ MultiFSClientSSH.prototype.rename = function(src, dest, cb) {
     return
   }
 
-  this.client.rename(src, dest, cb)
+  this.client.unlink(dest, function(err) {
+    // ignore ENOENT
+    if (err && err.message !== 'No such file')
+      return cb(err)
+    this.client.rename(src, dest, function(err) {
+      cb(err)
+    })
+  }.bind(this))
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -102,7 +102,7 @@ test('rmr', function(t) {
 })
 
 test('writeFilep', function(t) {
-  mf.writeFilep('a/x/y/z/foo', 'bar\n', 'ascii', function(er, res, data) {
+  mf.writeFilep('a/x/y/z/foo', 'new content\n', 'ascii', function(er, res, data) {
     if (er)
       throw er
     t.equal(res, undefined)
@@ -160,7 +160,7 @@ test('readFile', function(t) {
     mf.readFile('a/x/y/z/foo', 'ascii', function(er, res, data) {
       if (er)
         throw er
-      t.equal(res, 'bar\n')
+      t.equal(res, 'new content\n')
       t.end()
     })
   })
@@ -182,6 +182,18 @@ test('rename', function(t) {
     t.equal(res, undefined)
     t.end()
   })
+})
+
+test('rename blows away the destination', function(t) {
+    mf.rename('a/x/y/z/foo', 'a/b/c/bar', function(er, res, data) {
+      if (er) throw er
+      mf.readFile('a/b/c/bar', 'ascii', function(er, res, data) {
+        if (er) throw er
+        t.equal(res, 'new content\n')
+        t.pass('rename force')
+        t.end()
+      })
+    })
 })
 
 test('unlink', function(t) {


### PR DESCRIPTION
It ignores not-found errors, if present, then proceeds with the rename. This brings its behavior into line with the filesystem behavior of just blowing away existing files without a care.

Added a test specifically for this case.
