### PR TITLE
scp supports options.port

### DIFF
--- a/lib/client-scp.js
+++ b/lib/client-scp.js
@@ -30,6 +30,7 @@ function MultiFSClientSCP(options) {
 
   MultiFSClientSSH.call(this, options)
   this.strictHostKeyChecking = options.strictHostKeyChecking
+  this.port = options.port
   this.scpBase = options.user + '@' + options.host + ':'
 }
 util.inherits(MultiFSClientSCP, MultiFSClientSSH)
@@ -51,6 +52,11 @@ MultiFSClientSCP.prototype._scpToTmpFile = function _scpToTmpFile(p, tmpfile, cb
   if (typeof this.strictHostKeyChecking !== 'undefined') {
     opts.push('-o')
     opts.push('StrictHostKeyChecking=' + (this.strictHostKeyChecking ? 'yes' : 'no'))
+  }
+
+  if (typeof this.port !== 'undefined') {
+    opts.push('-P')
+    opts.push(this.port)
   }
 
   opts.push(tmpfile, p)

--- a/lib/client-ssh.js
+++ b/lib/client-ssh.js
@@ -41,6 +41,7 @@ function MultiFSClientSSH(options) {
   }
 
   if (options.identity) {
+    this.identity = options.identity
     options.key = fs.readFileSync(options.identity)
   }
 


### PR DESCRIPTION
SCP wasn't supporting other ports than 22. This commit adds `-P <port>` if a port is specified in the options.